### PR TITLE
inSPIRE-0.3 updated NCE range and msp formatting

### DIFF
--- a/inspire/__init__.py
+++ b/inspire/__init__.py
@@ -1,0 +1,4 @@
+""" Init file for inSPIRE package
+"""
+# Version of inSPIRE package
+__version__ = 0.3

--- a/inspire/calibration.py
+++ b/inspire/calibration.py
@@ -26,7 +26,7 @@ from inspire.prepare import write_prosit_input_df
 from inspire.spectral_features import calculate_spectral_features
 from inspire.utils import get_ox_flag, remove_source_suffixes
 
-COLLISION_ENERGY_RANGE = [24 + i for i in range(13)]
+COLLISION_ENERGY_RANGE = [20 + i for i in range(21)]
 
 def _get_top_hits(config):
     """ Function to extract the top scoring hits for collision energy calibration.
@@ -39,10 +39,10 @@ def _get_top_hits(config):
     target_df, mods_df = generic_read_df(config)
 
     target_df = target_df[target_df[PTM_SEQ_KEY].isna()]
-    top_10_pct_cut = target_df[ENGINE_SCORE_KEY].quantile(0.9)
+    top_5_pct_cut = target_df[ENGINE_SCORE_KEY].quantile(0.95)
 
     target_df = target_df[
-        (target_df[ENGINE_SCORE_KEY] > top_10_pct_cut) &
+        (target_df[ENGINE_SCORE_KEY] > top_5_pct_cut) &
         (target_df[LABEL_KEY] == 1)
     ]
 

--- a/inspire/input/msp.py
+++ b/inspire/input/msp.py
@@ -208,7 +208,7 @@ def process_prosit_comment(line, sequence):
         previous_ind = 0
         for mod in mods_list:
             if mod.startswith(OXIDATION_PREFIX):
-                pos = int(mod[OXIDATION_PREFIX_LEN:])
+                pos = int(mod[OXIDATION_PREFIX_LEN:]) - 1
                 mod_seq += sequence[previous_ind:pos]
                 mod_seq += "(ox)"
                 previous_ind = pos

--- a/inspire/prosit.py
+++ b/inspire/prosit.py
@@ -314,9 +314,9 @@ def generate_mods_string_tuples(sequence_integer):
     for mod in [PROSIT_ALPHABET['M(ox)'], PROSIT_ALPHABET['C']]:
         for position in np.where(sequence_integer == mod)[0]:
             if mod == PROSIT_ALPHABET['C']:
-                list_mods.append((position, "C", "Carbamidomethyl"))
+                list_mods.append((position + 1, "C", "Carbamidomethyl"))
             elif mod == PROSIT_ALPHABET['M(ox)']:
-                list_mods.append((position, "M", "Oxidation"))
+                list_mods.append((position + 1, "M", "Oxidation"))
             else:
                 raise ValueError("cant be true")
     list_mods.sort(key=lambda tup: tup[0])  # inplace

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='inspire',
-    version=0.2,
+    version=0.3,
     description='Helping to integrate Spectral Predictors and Rescoring.',
     author='John Cormican',
     author_email='john.cormican@mpinat.mpg.de',


### PR DESCRIPTION
Updates based on minor comments of reviewer:

- Updated the NCE range during calibration to 20-40 rather than 24-36.
- Also updated the formatting of modification used in msp read/write to match the prosit webserver formatting.