### PR TITLE
inSPIRE 1.1 Fixing Source File Read in For Mascot and Speed Up Plotting Utility

### DIFF
--- a/inspire/__init__.py
+++ b/inspire/__init__.py
@@ -1,4 +1,4 @@
 """ Init file for inSPIRE package
 """
 # Version of inSPIRE package
-__version__ = 1.0
+__version__ = 1.1

--- a/inspire/config.py
+++ b/inspire/config.py
@@ -35,6 +35,7 @@ ALL_CONFIG_KEYS = [
     'scanTitleFormat',
     'searchResults',
     'searchEngine',
+    'sourceFileName',
     'spectralPredictor',
     'useBindingAffinity',
     'useAccessionStrata',
@@ -123,6 +124,7 @@ class Config:
         self.source_files = None
         if 'distillerLog' in config_dict:
             self.source_files = read_distiller_log(config_dict['distillerLog'])
+        self.source_filename = config_dict.get('sourceFileName', None)
 
         # NetMhcPan
         self.use_binding_affinity = config_dict.get('useBindingAffinity', None)

--- a/inspire/input/mascot.py
+++ b/inspire/input/mascot.py
@@ -174,13 +174,12 @@ def separate_scan_and_source(df_row, scan_title_format, source_list=None, source
         df_row[SCAN_KEY] = int(scan_title.split('=')[-1].strip('~'))
         if source_filename is None:
             source = scan_title.split('File:')[-1]
+            if source.startswith('~'):
+                source = source.split('~')[1]
+            else:
+                source = source.split(', ')[0]
         else:
             source = source_filename
-
-        if source.startswith('~'):
-            source = source.split('~')[1]
-        else:
-            source = source.split(', ')[0]
 
         if source.endswith('.raw') or source.endswith('.mgf'):
             source = source[:-4]

--- a/inspire/input/mascot.py
+++ b/inspire/input/mascot.py
@@ -174,13 +174,18 @@ def separate_scan_and_source(df_row, scan_title_format, source_list=None, source
         df_row[SCAN_KEY] = int(scan_title.split('=')[-1].strip('~'))
         if source_filename is None:
             source = scan_title.split('File:')[-1]
-            if source.startswith('~'):
-                source = source.split('~')[1]
-            else:
-                source = source.split(', ')[0]
-            if source.endswith('.raw'):
-                source = source[:-4]
-            df_row[SOURCE_KEY] = source
+        else:
+            source = source_filename
+
+        if source.startswith('~'):
+            source = source.split('~')[1]
+        else:
+            source = source.split(', ')[0]
+
+        if source.endswith('.raw') or source.endswith('.mgf'):
+            source = source[:-4]
+        df_row[SOURCE_KEY] = source
+
     elif scan_title_format == 'mascotDistiller':
         scan_rt_details = scan_title.split(' Scan ')[-1].split(' (rt')
         df_row[SCAN_KEY] = int(scan_rt_details[0])

--- a/inspire/input/search_results.py
+++ b/inspire/input/search_results.py
@@ -34,6 +34,7 @@ def generic_read_df(config, save_dfs=True):
                 config.scan_title_format,
                 config.source_files,
                 config.reduce,
+                config.source_filename,
             )
         elif config.search_engine == 'maxquant':
             search_df, mods_df = read_mq_data(config.search_results)

--- a/inspire/plot_spectra.py
+++ b/inspire/plot_spectra.py
@@ -419,27 +419,35 @@ def fetch_scan_data(input_df, config, with_charge):
     """
     source_files = input_df[SOURCE_KEY].unique().tolist()
     scan_dfs = []
-    for scan_file in source_files:
-        scan_ids = input_df[input_df[SOURCE_KEY] == scan_file][SCAN_KEY].tolist()
-        if config.scans_format == 'mzML':
-            scan_df = process_mzml_file(
-                f'{config.scans_folder}/{scan_file}.{config.scans_format}',
-                scan_ids,
-                with_charge=with_charge,
-            )
-        else:
-            if config.combined_scans_file is not None:
-                mgf_filename = f'{config.scans_folder}/{config.combined_scans_file}'
+    if config.combined_scans_file is not None:
+        scan_ids = input_df[SCAN_KEY].tolist()
+        mgf_filename = f'{config.scans_folder}/{config.combined_scans_file}'
+        scan_dfs = [process_mgf_file(
+            mgf_filename,
+            set(scan_ids),
+            config.scan_title_format,
+            config.source_files,
+            with_charge=with_charge,
+        )]
+    else:
+        for scan_file in source_files:
+            scan_ids = input_df[input_df[SOURCE_KEY] == scan_file][SCAN_KEY].tolist()
+            if config.scans_format == 'mzML':
+                scan_df = process_mzml_file(
+                    f'{config.scans_folder}/{scan_file}.{config.scans_format}',
+                    set(scan_ids),
+                    with_charge=with_charge,
+                )
             else:
                 mgf_filename = f'{config.scans_folder}/{scan_file}.{config.scans_format}'
-            scan_df = process_mgf_file(
-                mgf_filename,
-                set(scan_ids),
-                config.scan_title_format,
-                config.source_files,
-                with_charge=with_charge,
-            )
-        scan_dfs.append(scan_df)
+                scan_df = process_mgf_file(
+                    mgf_filename,
+                    set(scan_ids),
+                    config.scan_title_format,
+                    config.source_files,
+                    with_charge=with_charge,
+                )
+            scan_dfs.append(scan_df)
     total_scan_df = pd.concat(scan_dfs)
     return total_scan_df
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='inspirems',
-    version=1.0,
+    version=1.1,
     description='Helping to integrate Spectral Predictors and Rescoring.',
     author='John Cormican, Juliane Liepe',
     author_email='juliane.liepe@mpinat.mpg.de',

--- a/test/unit/input/test_mascot.py
+++ b/test/unit/input/test_mascot.py
@@ -43,7 +43,8 @@ class TestMascot(unittest.TestCase):
             [self.target_file_path, self.decoy_file_path],
             None,
             None,
-            True
+            True,
+            None,
         )
         self.assertEqual(search_df.shape[0], 123)
         self.assertEqual(search_df.shape[0], search_df[MASCOT_PEP_QUERY_KEY].nunique())
@@ -58,6 +59,7 @@ class TestMascot(unittest.TestCase):
             None,
             None,
             False,
+            None,
         )
         self.assertEqual(search_df.shape[0], 239)
         self.assertGreater(search_df.shape[0], search_df[MASCOT_PEP_QUERY_KEY].nunique())


### PR DESCRIPTION
Fixing the issue pointed out on:
https://github.com/QuantSysBio/inSPIRE/issues/6

Also speeding up the read in when using the plotting utility with a combined MGF file.