### PR TITLE
inSPIRE-1.2 Callibration on Mascot Results and Unknown Modification Filtering

### DIFF
--- a/inspire/__init__.py
+++ b/inspire/__init__.py
@@ -1,4 +1,4 @@
 """ Init file for inSPIRE package
 """
 # Version of inSPIRE package
-__version__ = 1.1
+__version__ = 1.2

--- a/inspire/config.py
+++ b/inspire/config.py
@@ -110,7 +110,7 @@ class Config:
         self.reduce = config_dict.get('reduce', False)
         self.rescore_method = config_dict.get('rescoreMethod', 'mokapot')
 
-        self.filter_c = config_dict.get('filterCysteine', False)
+        self.filter_c = config_dict.get('filterCysteine', True)
         if self.spectral_predictor == 'prosit':
             self.drop_unknown_mods = config_dict.get('dropUnknownPTMs', True)
         else:

--- a/inspire/input/mascot.py
+++ b/inspire/input/mascot.py
@@ -351,8 +351,6 @@ def _add_fixed_mod(peptide, ptm_seq, fixed_ptm_dict):
     ptm_seq : str
         The input ptm_seq updated with any relevant fixed modifications.
     """
-    if not isinstance(ptm_seq, str):
-        ptm_seq = '0.' + ''.join(['0']*len(peptide)) + '.0'
     for residues in fixed_ptm_dict:
         if residues == 'N-term':
             if not isinstance(ptm_seq, str):

--- a/inspire/input/mascot.py
+++ b/inspire/input/mascot.py
@@ -355,12 +355,18 @@ def _add_fixed_mod(peptide, ptm_seq, fixed_ptm_dict):
         ptm_seq = '0.' + ''.join(['0']*len(peptide)) + '.0'
     for residues in fixed_ptm_dict:
         if residues == 'N-term':
+            if not isinstance(ptm_seq, str):
+                ptm_seq = '0.' + ''.join(['0']*len(peptide)) + '.0'
             ptm_seq = fixed_ptm_dict[residues] + ptm_seq[1:]
         elif residues == 'C-term':
+            if not isinstance(ptm_seq, str):
+                ptm_seq = '0.' + ''.join(['0']*len(peptide)) + '.0'
             ptm_seq = ptm_seq[:-1] + fixed_ptm_dict[residues]
         else:
             for res in residues:
                 ptm_postns = [m.start() for m in re.finditer(res, peptide)]
+                if ptm_postns and not isinstance(ptm_seq, str):
+                    ptm_seq = '0.' + ''.join(['0']*len(peptide)) + '.0'
                 for pos in ptm_postns:
                     ptm_seq = ptm_seq[:pos+2] + str(fixed_ptm_dict[residues]) + ptm_seq[pos+3:]
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='inspirems',
-    version=1.1,
+    version=1.2,
     description='Helping to integrate Spectral Predictors and Rescoring.',
     author='John Cormican, Juliane Liepe',
     author_email='juliane.liepe@mpinat.mpg.de',

--- a/test/unit/test_feature_creation.py
+++ b/test/unit/test_feature_creation.py
@@ -1,0 +1,55 @@
+""" Test suite for the inSPIRE feature_creation utilities.
+"""
+import unittest
+
+import pandas as pd
+
+from inspire.config import Config
+from inspire.feature_creation import process_unknown_modifications
+
+class TestFeatureCreation(unittest.TestCase):
+    """ Testing suite for the inSPIRE feature_creation input utilities.
+    """
+    def setUp(self):
+        self.config = Config('test/resources/config.yml')
+        self.target_df = pd.read_csv('test/resources/formatted_search.csv')
+        self.mods_df = pd.read_csv('test/resources/mods_df.csv')
+
+    def test_process_unknown_modifications_default_without_unknown(self):
+        """ Function to test the process_unknown_modifications function with default settings.
+        """
+        processed_df = process_unknown_modifications(
+            self.target_df,
+            self.mods_df,
+            self.config
+        )
+        self.assertEqual(processed_df.shape[0], 408)
+
+    def test_process_unknown_modifications_default_with_unknown(self):
+        """ Function to test the process_unknown_modifications function
+            with an unknown modification.
+        """
+        self.mods_df['Name'] = 'blah'
+        processed_df = process_unknown_modifications(
+            self.target_df,
+            self.mods_df,
+            self.config
+        )
+        self.assertEqual(processed_df.shape[0], 399)
+
+    def test_process_unknown_modifications_keep(self):
+        """ Function to test the process_unknown_modifications with all results kept.
+        """
+        self.config.filter_c = False
+        self.config.drop_unknown_mods = False
+        self.mods_df['Name'] = 'blah'
+        processed_df = process_unknown_modifications(
+            self.target_df,
+            self.mods_df,
+            self.config
+        )
+        self.assertEqual(processed_df.shape[0], 409)
+
+    
+
+


### PR DESCRIPTION
Improvements to:
1) deal with edge case leading to problems with collision energy calibration of Mascot search results. (No issues for PEAKS or MaxQuant).
2) clean up the section on dropping unknown PTMs where the logic was confusing. Now separated into it's own function.
3) add unit testing for the dropping of unknown PTMs.