### PR TITLE
inSPIRE-1.3 Allow multiple Collision Energy Settings

### DIFF
--- a/inspire/calibration.py
+++ b/inspire/calibration.py
@@ -150,7 +150,7 @@ def calibrate(config):
             '1',
             config.delta_method,
             config.spectral_predictor,
-            spectral_angle_only=True,
+            minimal_features=True,
         ),
         axis=1
     )

--- a/inspire/config.py
+++ b/inspire/config.py
@@ -37,8 +37,9 @@ ALL_CONFIG_KEYS = [
     'searchEngine',
     'sourceFileName',
     'spectralPredictor',
-    'useBindingAffinity',
     'useAccessionStrata',
+    'useBindingAffinity',
+    'useMinimalFeatures',
 ]
 
 class Config:
@@ -101,6 +102,7 @@ class Config:
         else:
             self.delta_method = config_dict.get('deltaMethod', 'ignore')
         self.reuse_input = config_dict.get('reuseInput', False)
+        self.minimal_features = config_dict.get('useMinimalFeatures', False)
 
         # Optional
         self.fdr = config_dict.get('falseDiscoveryRate', 0.01)

--- a/inspire/config.py
+++ b/inspire/config.py
@@ -36,6 +36,7 @@ ALL_CONFIG_KEYS = [
     'searchResults',
     'searchEngine',
     'sourceFileName',
+    'spectralAngleDfs',
     'spectralPredictor',
     'useAccessionStrata',
     'useBindingAffinity',
@@ -111,6 +112,7 @@ class Config:
         self.include_features = config_dict.get('includeFeatures', None)
         self.reduce = config_dict.get('reduce', False)
         self.rescore_method = config_dict.get('rescoreMethod', 'mokapot')
+        self.sa_query_dfs = config_dict.get('spectralAngleDfs', None)
 
         self.filter_c = config_dict.get('filterCysteine', True)
         if self.spectral_predictor == 'prosit':

--- a/inspire/constants.py
+++ b/inspire/constants.py
@@ -100,6 +100,11 @@ OUT_Q_KEY = {
     'percolator': 'q-value',
     'percolatorSeparate': 'q-value',
 }
+OUT_POSTEP_KEY = {
+    'mokapot': 'mokapot PEP',
+    'percolator': 'posterior_error_prob',
+    'percolatorSeparate': 'posterior_error_prob',
+}
 
 PREFIX_KEYS = {
     'mokapot': [PSM_ID_KEY['mokapot'], LABEL_KEY, PERC_SCAN_ID],
@@ -113,6 +118,7 @@ SUFFIX_KEYS = {
 }
 FINAL_SCORE_KEY = 'percolatorScore'
 FINAL_Q_VALUE_KEY = 'qValue'
+FINAL_POSTEP_KEY = 'postErrProb'
 
 PRED_ACCESSION_KEY = 'predictedAccession'
 PRED_PEPTIDE_KEY = 'predictedPeptide'

--- a/inspire/constants.py
+++ b/inspire/constants.py
@@ -301,6 +301,12 @@ DELTA_PRO_FEATURES = [
     'BLOSUM6.1',
 ]
 
+MINIMAL_FEATURE_SET = [
+    SPECTRAL_ANGLE_KEY,
+    ENGINE_SCORE_KEY,
+    'matchedCoverage',
+    'deltaRT',
+]
 
 # Constants used by deltapro predictor.
 

--- a/inspire/feature_creation.py
+++ b/inspire/feature_creation.py
@@ -428,9 +428,7 @@ def process_single_file(
     combined_df = create_spectral_features(combined_df, mods_df, config)
     combined_df = combined_df.sort_values(by='spectralAngle', ascending=False)
     if isinstance(config.collision_energy, list):
-        combined_df.to_csv('temp.csv', index=False)
         combined_df = combined_df.drop_duplicates(subset=['source', 'scan', 'peptide'])
-        combined_df.to_csv('temp2.csv', index=False)
 
     combined_df = add_delta_irt(combined_df)
 

--- a/inspire/feature_selection.py
+++ b/inspire/feature_selection.py
@@ -20,6 +20,7 @@ from inspire.constants import (
     LABEL_KEY,
     LOSS_IONS_KEY,
     MASS_DIFF_KEY,
+    MINIMAL_FEATURE_SET,
     NOT_ASSIGNED_KEY,
     OKCYAN_TEXT,
     OUT_SCORE_KEY,
@@ -134,8 +135,12 @@ SPECTRAL_GROUP_NAMES = [
     'Y/B Ion Difference Features',
 ]
 
+
+
+
+
 DEFAULT_FEATURE_SET = [
-    'engineScore',
+    ENGINE_SCORE_KEY,
     'deltaScore',
     'sequenceLength',
     'seqLenMeanDiff',
@@ -618,7 +623,6 @@ def filter_feature_set(all_features_df, config, base_features):
 
     return all_features_df, feature_set
 
-
 def select_features(config):
     """ Function to select the features used in the final percolator model.
 
@@ -633,17 +637,16 @@ def select_features(config):
     )
 
     if config.max_for_selection < all_features_df.shape[0]:
-        feature_set = DEFAULT_FEATURE_SET
-        if config.delta_method == 'ignore':
-            feature_set = [x for x in feature_set if x not in DELTA_FEATURES]
+        if config.minimal_features:
+            feature_set = MINIMAL_FEATURE_SET
+        else:
+            feature_set = DEFAULT_FEATURE_SET
+            if config.delta_method == 'ignore':
+                feature_set = [x for x in feature_set if x not in DELTA_FEATURES]
+
         if config.use_binding_affinity == 'asFeature':
             feature_set += ['bindingAffinity']
-        # all_features_df, one_hot_features = generate_one_hot_entries(
-        #     all_features_df,
-        #     'charge'
-        # )
-        # feature_set += one_hot_features
-        # feature_set.remove('charge')
+
         if config.exclude_features is not None and config.exclude_features:
             exclude_features = (
                 config.exclude_features +

--- a/inspire/get_spectral_angle.py
+++ b/inspire/get_spectral_angle.py
@@ -1,0 +1,93 @@
+""" Functions for simple pipeline to get spectral angle on of identified PSMs.
+"""
+import pandas as pd
+
+from inspire.constants import(
+    CHARGE_KEY,
+    KNOWN_PTM_WEIGHTS,
+    SCAN_KEY,
+    SOURCE_KEY,
+)
+from inspire.input.msp import msp_to_df
+from inspire.predict_spectra import predict_spectra
+from inspire.retention_time import add_delta_irt
+from inspire.spectral_features import calculate_spectral_features
+from inspire.utils import convert_mod_seq_to_ptm_seq, fetch_scan_data
+
+def get_spectral_angle(config):
+    """ Function to generate pair plots of selected PSMs (experimental vs. Prosit
+        predicted spectra.).
+
+    Parameters
+    ----------
+    config : inspire.config.Config
+        The Config object used to run the inSPIRE experiment.
+    """
+    for dataset in config.sa_query_dfs:
+        input_df = pd.read_csv(dataset)
+        output_loc = dataset.split('.csv')[0] + '_spectralAngle.csv'
+        input_cols = list(input_df.columns)
+        print(input_cols)
+
+        get_charge_from_scan_file = not CHARGE_KEY in input_df.columns
+        scan_df = fetch_scan_data(input_df, config, get_charge_from_scan_file)
+
+        input_df = pd.merge(
+            input_df,
+            scan_df,
+            how='inner',
+            on=[SOURCE_KEY, SCAN_KEY]
+        )
+
+        input_df['modified_sequence'] = input_df['modifiedSequence'].apply(
+            lambda x : x.replace('[+16.0]', '(ox)').replace('[+57.0]', '')
+        )
+        input_df['precursor_charge'] = input_df[CHARGE_KEY]
+        input_df['collision_energy'] = config.collision_energy
+        input_df[['modified_sequence', 'precursor_charge', 'collision_energy']].to_csv(
+            f'{config.output_folder}/saInput.csv', index=False,
+        )
+
+        predict_spectra(config, pipeline='spectralAngle')
+        prosit_df = msp_to_df(f'{config.output_folder}/saPredictions.msp', 'prosit', None)
+        prosit_df = prosit_df.drop_duplicates(subset=['modified_sequence', CHARGE_KEY])
+
+        input_df = pd.merge(
+            input_df,
+            prosit_df,
+            how='inner',
+            on=['modified_sequence', CHARGE_KEY]
+        )
+
+        input_df = input_df.reset_index(drop=True)
+
+        input_df['ptm_seq'] = input_df['modifiedSequence'].apply(
+            convert_mod_seq_to_ptm_seq
+        )
+        input_df = input_df.apply(
+            lambda x : calculate_spectral_features(
+                x,
+                {
+                    0: 0.0,
+                    1: KNOWN_PTM_WEIGHTS['Oxidation (M)'],
+                    2: KNOWN_PTM_WEIGHTS['Carbamidomethylation'],
+                },
+                config.mz_accuracy,
+                config.mz_units,
+                None,
+                '1',
+                config.delta_method,
+                config.spectral_predictor,
+                minimal_features=True,
+            ),
+            axis=1,
+        )
+        input_df = add_delta_irt(input_df)
+        print(
+            dataset,
+            input_df['deltaRT'].mean(),
+            input_df['deltaRT'].median()
+        )
+        input_df[input_cols + ['deltaRT', 'spectralAngle']].to_csv(
+            output_loc
+        )

--- a/inspire/get_spectral_angle.py
+++ b/inspire/get_spectral_angle.py
@@ -27,7 +27,6 @@ def get_spectral_angle(config):
         input_df = pd.read_csv(dataset)
         output_loc = dataset.split('.csv')[0] + '_spectralAngle.csv'
         input_cols = list(input_df.columns)
-        print(input_cols)
 
         get_charge_from_scan_file = not CHARGE_KEY in input_df.columns
         scan_df = fetch_scan_data(input_df, config, get_charge_from_scan_file)
@@ -43,7 +42,11 @@ def get_spectral_angle(config):
             lambda x : x.replace('[+16.0]', '(ox)').replace('[+57.0]', '')
         )
         input_df['precursor_charge'] = input_df[CHARGE_KEY]
-        input_df['collision_energy'] = config.collision_energy
+        if 'collisionEnergy' in input_df.columns:
+            input_df = input_df.rename(columns={'collisionEnergy': 'collision_energy'})
+        else:
+            input_df['collision_energy'] = config.collision_energy
+
         input_df[['modified_sequence', 'precursor_charge', 'collision_energy']].to_csv(
             f'{config.output_folder}/saInput.csv', index=False,
         )
@@ -82,12 +85,8 @@ def get_spectral_angle(config):
             ),
             axis=1,
         )
+
         input_df = add_delta_irt(input_df)
-        print(
-            dataset,
-            input_df['deltaRT'].mean(),
-            input_df['deltaRT'].median()
-        )
         input_df[input_cols + ['deltaRT', 'spectralAngle']].to_csv(
             output_loc
         )

--- a/inspire/input/mgf.py
+++ b/inspire/input/mgf.py
@@ -10,11 +10,19 @@ from inspire.constants import (
     CHARGE_KEY,
     INTENSITIES_KEY,
     MZS_KEY,
+    RT_KEY,
     SCAN_KEY,
     SOURCE_KEY,
 )
 
-def process_mgf_file(mgf_filename, scan_ids, scan_file_format, source_list, with_charge=False):
+def process_mgf_file(
+        mgf_filename,
+        scan_ids,
+        scan_file_format,
+        source_list,
+        with_charge=False,
+        with_retention_time=False,
+    ):
     """ Function to process an mgf file to find matches with scan IDs.
 
     Parameters
@@ -40,6 +48,8 @@ def process_mgf_file(mgf_filename, scan_ids, scan_file_format, source_list, with
     filename = mgf_filename.split('/')[-1]
     if with_charge:
         charge_list = []
+    if with_retention_time:
+        rt_list = []
 
     with mgf.read(mgf_filename) as reader:
         for spectrum in reader:
@@ -66,6 +76,8 @@ def process_mgf_file(mgf_filename, scan_ids, scan_file_format, source_list, with
                 matched_mzs.append(np.array(list(spectrum['m/z array'])))
                 if with_charge:
                     charge_list.append(int(spectrum['params']['charge'][0]))
+                if with_retention_time:
+                    rt_list.append(float(spectrum['params']['rtinseconds']))
 
     mgf_df = pd.DataFrame(
         {
@@ -77,6 +89,8 @@ def process_mgf_file(mgf_filename, scan_ids, scan_file_format, source_list, with
     )
     if with_charge:
         mgf_df[CHARGE_KEY] = pd.Series(charge_list)
+    if with_retention_time:
+        mgf_df[RT_KEY] = pd.Series(rt_list)
 
     mgf_df = mgf_df.drop_duplicates(subset=[SOURCE_KEY, SCAN_KEY])
 

--- a/inspire/plot_spectra.py
+++ b/inspire/plot_spectra.py
@@ -505,7 +505,12 @@ def plot_spectra(config):
         lambda x : x.replace('[+16.0]', '(ox)').replace('[+57.0]', '')
     )
     input_df['precursor_charge'] = input_df[CHARGE_KEY]
-    input_df['collision_energy'] = config.collision_energy
+
+    if 'collisionEnergy' in input_df.columns:
+        input_df = input_df.rename(columns={'collisionEnergy': 'collision_energy'})
+    else:
+        input_df['collision_energy'] = config.collision_energy
+
     input_df[['modified_sequence', 'precursor_charge', 'collision_energy']].to_csv(
         f'{config.output_folder}/plotInput.csv', index=False,
     )

--- a/inspire/plot_spectra.py
+++ b/inspire/plot_spectra.py
@@ -18,13 +18,13 @@ from inspire.constants import (
     SOURCE_KEY,
     SPECTRAL_ANGLE_KEY,
 )
-from inspire.input.mgf import process_mgf_file
+
 
 from inspire.input.msp import msp_to_df
-from inspire.input.mzml import process_mzml_file
 from inspire.mz_match import get_ion_masses
 from inspire.predict_spectra import predict_spectra
 from inspire.spectral_features import calculate_spectral_features
+from inspire.utils import fetch_scan_data, convert_mod_seq_to_ptm_seq
 
 PLOTS_PER_PAGE = 15
 PLOTS_PER_LINE = 3
@@ -402,82 +402,6 @@ def pair_plot(df_row, mz_accuracy, mz_units):
 
     return traces, annotations
 
-def fetch_scan_data(input_df, config, with_charge):
-    """ Function to fetch the experimental scan data.
-
-    Parameters
-    ----------
-    input_df : pd.DataFrame
-        The DataFrame of PSMs whose spectra we wish to plot.
-    config : inspire.config.Config
-        The Config object used to run the inSPIRE experiment.
-
-    Returns
-    -------
-    total_scan_df : pd.DataFrame
-        A DataFrame of the necessary scan data.
-    """
-    source_files = input_df[SOURCE_KEY].unique().tolist()
-    scan_dfs = []
-    if config.combined_scans_file is not None:
-        scan_ids = input_df[SCAN_KEY].tolist()
-        mgf_filename = f'{config.scans_folder}/{config.combined_scans_file}'
-        scan_dfs = [process_mgf_file(
-            mgf_filename,
-            set(scan_ids),
-            config.scan_title_format,
-            config.source_files,
-            with_charge=with_charge,
-        )]
-    else:
-        for scan_file in source_files:
-            scan_ids = input_df[input_df[SOURCE_KEY] == scan_file][SCAN_KEY].tolist()
-            if config.scans_format == 'mzML':
-                scan_df = process_mzml_file(
-                    f'{config.scans_folder}/{scan_file}.{config.scans_format}',
-                    set(scan_ids),
-                    with_charge=with_charge,
-                )
-            else:
-                mgf_filename = f'{config.scans_folder}/{scan_file}.{config.scans_format}'
-                scan_df = process_mgf_file(
-                    mgf_filename,
-                    set(scan_ids),
-                    config.scan_title_format,
-                    config.source_files,
-                    with_charge=with_charge,
-                )
-            scan_dfs.append(scan_df)
-    total_scan_df = pd.concat(scan_dfs)
-    return total_scan_df
-
-def convert_mod_seq_to_ptm_seq(mod_seq):
-    """ Function to convert the modified prosit sequence to the PTM seq used elsewhere.
-
-    Parameters
-    ----------
-    mod_seq : str
-        The input sequence for Prosit.
-
-    Returns
-    -------
-    ptm_seq : str
-        The string of digits used to represent any PTMs present.
-    """
-    ptm_seq = '0.'
-    while mod_seq:
-        if len(mod_seq) == 1 or mod_seq[1] != '[':
-            ptm_seq += '0'
-            mod_seq = mod_seq[1:]
-        elif mod_seq[1] == '[' and mod_seq[0] == 'C':
-            ptm_seq += '2'
-            mod_seq = mod_seq[8:]
-        else:
-            ptm_seq += '1'
-            mod_seq = mod_seq[8:]
-
-    ptm_seq += '.0'
-    return ptm_seq
 
 def plot_spectra(config):
     """ Function to generate pair plots of selected PSMs (experimental vs. Prosit

--- a/inspire/plot_spectra.py
+++ b/inspire/plot_spectra.py
@@ -547,7 +547,7 @@ def plot_spectra(config):
                 '1',
                 config.delta_method,
                 config.spectral_predictor,
-                spectral_angle_only=True,
+                minimal_features=True,
             ),
             axis=1,
         )

--- a/inspire/prepare.py
+++ b/inspire/prepare.py
@@ -90,22 +90,43 @@ def write_prosit_input_df(
     prosit_df = search_df[['modified_sequence', CHARGE_KEY]].rename(
         columns={CHARGE_KEY: 'precursor_charge'}
     )
-    prosit_df['collision_energy'] = collision_energy
-    prosit_df = prosit_df.drop_duplicates()
-    if overwrite:
-        prosit_df.to_csv(
-            f'{config.output_folder}/{filename}.csv',
-            index=False,
-        )
-    else:
-        prosit_df.to_csv(
-            f'{config.output_folder}/{filename}.csv',
-            index=False,
-            mode='a',
-            header=False,
-        )
+    if isinstance(collision_energy, list):
+        prosit_df = prosit_df.drop_duplicates()
+        prosit_df['collision_energy'] = [collision_energy for _ in prosit_df.index]
+        prosit_df = prosit_df.explode('collision_energy')
+        if overwrite:
+            prosit_df.to_csv(
+                f'{config.output_folder}/{filename}.csv',
+                index=False,
+            )
+        else:
+            prosit_df.to_csv(
+                f'{config.output_folder}/{filename}.csv',
+                index=False,
+                mode='a',
+                header=False,
+            )
+    else: 
+        prosit_df['collision_energy'] = collision_energy
+        prosit_df = prosit_df.drop_duplicates()
+        if overwrite:
+            prosit_df.to_csv(
+                f'{config.output_folder}/{filename}.csv',
+                index=False,
+            )
+        else:
+            prosit_df.to_csv(
+                f'{config.output_folder}/{filename}.csv',
+                index=False,
+                mode='a',
+                header=False,
+            )
 
     if config.delta_method == 'bruteForce' and filename == 'prositInput':
+        if isinstance(collision_energy, list):
+            raise NotImplementedError(
+                'bruteForce delta computation not supported for multiple NCE settings.'
+            )
         prosit_df['mSeq'] = prosit_df['modified_sequence'].apply(
             lambda x : x.replace('M(ox)', 'm')
         )

--- a/inspire/prepare.py
+++ b/inspire/prepare.py
@@ -106,7 +106,7 @@ def write_prosit_input_df(
                 mode='a',
                 header=False,
             )
-    else: 
+    else:
         prosit_df['collision_energy'] = collision_energy
         prosit_df = prosit_df.drop_duplicates()
         if overwrite:

--- a/inspire/report.py
+++ b/inspire/report.py
@@ -9,12 +9,14 @@ from inspire.constants import (
     DELTA_SCORE_KEY,
     ENDC_TEXT,
     ENGINE_SCORE_KEY,
+    FINAL_POSTEP_KEY,
     FINAL_Q_VALUE_KEY,
     FINAL_SCORE_KEY,
     MASS_DIFF_KEY,
     OKCYAN_TEXT,
     OUT_PSM_ID_KEY,
     OUT_Q_KEY,
+    OUT_POSTEP_KEY,
     OUT_SCORE_KEY,
     PEPTIDE_KEY,
     PREFIX_KEYS,
@@ -228,7 +230,7 @@ def calculate_fdr_cut_offs(
             assignment_df,
             binders_df,
             q_cut,
-            FINAL_Q_VALUE_KEY,
+            FINAL_POSTEP_KEY,
         )
         n_spire_psms.append(car_stats[0])
         n_spire_binders.append(car_stats[1])
@@ -347,7 +349,7 @@ def generate_report(config):
         fdrs_df = calculate_fdr_cut_offs(
             assignment_df,
             non_spectral_df,
-            OUT_Q_KEY[config.rescore_method],
+            OUT_POSTEP_KEY[config.rescore_method],
             binders_df,
             ns_binders_df
         )
@@ -355,7 +357,7 @@ def generate_report(config):
         fdrs_df = calculate_fdr_cut_offs(
             assignment_df,
             non_spectral_df,
-            OUT_Q_KEY[config.rescore_method],
+            OUT_POSTEP_KEY[config.rescore_method],
         )
 
     if config.use_binding_affinity:

--- a/inspire/report.py
+++ b/inspire/report.py
@@ -9,14 +9,12 @@ from inspire.constants import (
     DELTA_SCORE_KEY,
     ENDC_TEXT,
     ENGINE_SCORE_KEY,
-    FINAL_POSTEP_KEY,
     FINAL_Q_VALUE_KEY,
     FINAL_SCORE_KEY,
     MASS_DIFF_KEY,
     OKCYAN_TEXT,
     OUT_PSM_ID_KEY,
     OUT_Q_KEY,
-    OUT_POSTEP_KEY,
     OUT_SCORE_KEY,
     PEPTIDE_KEY,
     PREFIX_KEYS,
@@ -230,7 +228,7 @@ def calculate_fdr_cut_offs(
             assignment_df,
             binders_df,
             q_cut,
-            FINAL_POSTEP_KEY,
+            FINAL_Q_VALUE_KEY,
         )
         n_spire_psms.append(car_stats[0])
         n_spire_binders.append(car_stats[1])
@@ -349,7 +347,7 @@ def generate_report(config):
         fdrs_df = calculate_fdr_cut_offs(
             assignment_df,
             non_spectral_df,
-            OUT_POSTEP_KEY[config.rescore_method],
+            OUT_Q_KEY[config.rescore_method],
             binders_df,
             ns_binders_df
         )
@@ -357,7 +355,7 @@ def generate_report(config):
         fdrs_df = calculate_fdr_cut_offs(
             assignment_df,
             non_spectral_df,
-            OUT_POSTEP_KEY[config.rescore_method],
+            OUT_Q_KEY[config.rescore_method],
         )
 
     if config.use_binding_affinity:

--- a/inspire/rescore.py
+++ b/inspire/rescore.py
@@ -10,10 +10,12 @@ from inspire.constants import (
     CHARGE_KEY,
     ENDC_TEXT,
     ENGINE_SCORE_KEY,
+    FINAL_POSTEP_KEY,
     FINAL_Q_VALUE_KEY,
     FINAL_SCORE_KEY,
     OKCYAN_TEXT,
     OUT_ACCESSION_KEY,
+    OUT_POSTEP_KEY,
     OUT_Q_KEY,
     OUT_SCORE_KEY,
     PEPTIDE_KEY,
@@ -172,6 +174,9 @@ def _add_key_features(target_psms, config):
         )
         key_features.append(ACCESSION_STRATUM_KEY)
 
+    if isinstance(config.collision_energy, list):
+        key_features.append('collisionEnergy')
+
     output_df = pd.merge(
         target_psms,
         input_df[[psm_id_key, PEPTIDE_KEY] + key_features],
@@ -191,6 +196,7 @@ def final_rescoring(config):
     """
     out_score_key = OUT_SCORE_KEY[config.rescore_method]
     out_q_key = OUT_Q_KEY[config.rescore_method]
+    out_postep_key = OUT_POSTEP_KEY[config.rescore_method]
     psm_id_key = PSM_ID_KEY[config.rescore_method]
     out_accession_key = OUT_ACCESSION_KEY[config.rescore_method]
 
@@ -206,7 +212,7 @@ def final_rescoring(config):
     )
 
     if 'PSMId' in target_psms.columns:
-        target_psms = target_psms.rename(  # pylint: disable=no-member
+        target_psms = target_psms.rename( # pylint: disable=no-member
             columns={'PSMId': psm_id_key}
         )
 
@@ -225,8 +231,10 @@ def final_rescoring(config):
             out_score_key: FINAL_SCORE_KEY,
             out_q_key: FINAL_Q_VALUE_KEY,
             out_accession_key: ACCESSION_KEY,
+            out_postep_key: FINAL_POSTEP_KEY,
         }
     )
+
     final_columns = (
         [
             SOURCE_KEY,
@@ -235,6 +243,7 @@ def final_rescoring(config):
             'modifiedSequence',
             FINAL_SCORE_KEY,
             FINAL_Q_VALUE_KEY,
+            FINAL_POSTEP_KEY,
         ] + key_features +
         [
             ACCESSION_KEY

--- a/test/unit/input/test_mgf.py
+++ b/test/unit/input/test_mgf.py
@@ -1,0 +1,52 @@
+""" Test suite for the inSPIRE mgf input utilities.
+"""
+import unittest
+
+from inspire.constants import CHARGE_KEY, RT_KEY
+from inspire.input.mgf import process_mgf_file
+
+EXPECTED_OUTPUT_COLUMNS = [
+    'source', 'scan', 'intensities', 'mzs'
+]
+SCANS_TO_SELECT = {
+    1779, 2358, 2603, 2604, 217, 335,
+}
+
+class TestMgf(unittest.TestCase):
+    """ Testing suite for the inSPIRE mgf input utilities.
+    """
+    def test_process_mgf_file_default(self):
+        """ Test process mgf file.
+        """
+        mgf_df = process_mgf_file('test/resources/test.mgf', None, None, None)
+        self.assertEqual(mgf_df.shape[0], 931)
+        self.assertEqual(list(mgf_df.columns), EXPECTED_OUTPUT_COLUMNS)
+
+    def test_process_mgf_file_filter_scans(self):
+        """ Test process mgf file.
+        """
+        mgf_df = process_mgf_file('test/resources/test.mgf', SCANS_TO_SELECT, None, None)
+        self.assertEqual(mgf_df.shape[0], 6)
+        self.assertEqual(list(mgf_df.columns), EXPECTED_OUTPUT_COLUMNS)
+
+    def test_process_mgf_file_filter_scans_with_charge(self):
+        """ Test process mgf file including charge column.
+        """
+        mgf_df = process_mgf_file(
+            'test/resources/test.mgf',
+            SCANS_TO_SELECT,
+            None,
+            None,
+            with_charge=True,
+        )
+        self.assertEqual(mgf_df.shape[0], 6)
+        self.assertEqual(list(mgf_df.columns), EXPECTED_OUTPUT_COLUMNS + [CHARGE_KEY])
+
+    def test_process_mgf_file_filter_scans_with_rt(self):
+        """ Test process mgf file including rt column.
+        """
+        mgf_df = process_mgf_file(
+            'test/resources/test.mgf', SCANS_TO_SELECT, None, None, with_retention_time=True
+        )
+        self.assertEqual(mgf_df.shape[0], 6)
+        self.assertEqual(list(mgf_df.columns), EXPECTED_OUTPUT_COLUMNS + [RT_KEY])

--- a/test/unit/input/test_mzml.py
+++ b/test/unit/input/test_mzml.py
@@ -1,0 +1,47 @@
+""" Test suite for the inSPIRE mzML input utilities.
+"""
+import unittest
+
+from inspire.constants import CHARGE_KEY, RT_KEY
+from inspire.input.mzml import process_mzml_file
+
+EXPECTED_OUTPUT_COLUMNS = [
+    'source', 'scan', 'intensities', 'mzs'
+]
+SCANS_TO_SELECT = {
+    1779, 746, 923, 2417, 2482, 3300,
+}
+
+class TestMzML(unittest.TestCase):
+    """ Testing suite for the inSPIRE mzML input utilities.
+    """
+    def test_process_mzml_file_default(self):
+        """ Test process mzML file.
+        """
+        mzml_df = process_mzml_file('test/resources/test.mzML', None)
+        self.assertEqual(mzml_df.shape[0], 1263)
+        self.assertEqual(list(mzml_df.columns), EXPECTED_OUTPUT_COLUMNS)
+
+    def test_process_mzml_file_filter_scans(self):
+        """ Test process mzML file.
+        """
+        mzml_df = process_mzml_file('test/resources/test.mzML', SCANS_TO_SELECT)
+        self.assertEqual(mzml_df.shape[0], 6)
+        self.assertEqual(list(mzml_df.columns), EXPECTED_OUTPUT_COLUMNS)
+
+    def test_process_mzml_file_filter_scans_with_charge(self):
+        """ Test process mzML file including charge column.
+        """
+        mzml_df = process_mzml_file('test/resources/test.mzML', SCANS_TO_SELECT, with_charge=True)
+        self.assertEqual(mzml_df.shape[0], 6)
+        self.assertEqual(list(mzml_df.columns), EXPECTED_OUTPUT_COLUMNS + [CHARGE_KEY])
+
+    def test_process_mzml_file_filter_scans_with_rt(self):
+        """ Test process mzML file including rt column.
+        """
+        mzml_df = process_mzml_file(
+            'test/resources/test.mzML', SCANS_TO_SELECT, with_retention_time=True
+        )
+        print(mzml_df)
+        self.assertEqual(mzml_df.shape[0], 6)
+        self.assertEqual(list(mzml_df.columns), EXPECTED_OUTPUT_COLUMNS + [RT_KEY])

--- a/test/unit/input/test_mzml.py
+++ b/test/unit/input/test_mzml.py
@@ -42,6 +42,5 @@ class TestMzML(unittest.TestCase):
         mzml_df = process_mzml_file(
             'test/resources/test.mzML', SCANS_TO_SELECT, with_retention_time=True
         )
-        print(mzml_df)
         self.assertEqual(mzml_df.shape[0], 6)
         self.assertEqual(list(mzml_df.columns), EXPECTED_OUTPUT_COLUMNS + [RT_KEY])


### PR DESCRIPTION
A number of improvements:

- Allow multiple Collision Energy Settings to be used for per PSM CE callibration.
- Fetch RT from mgf/mzml file if the column is empty in the search results.
- Unit tests for mgf/mzml input utilities
- Create separate pipeline for spectral angle computation only.
- Use of minimal feature set for small datasets.
- Added posterior error probability to finalAssignments output.